### PR TITLE
Added base code for code coverage, and coverage testing + new tests for Rect2::intersects_transformed

### DIFF
--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -34,6 +34,8 @@
 #include "core/math/transform_2d.h"
 #include "core/string/ustring.h"
 
+int rect2_coverage_testing_data_structure[100];
+
 bool Rect2::is_equal_approx(const Rect2 &p_rect) const {
 	return position.is_equal_approx(p_rect.position) && size.is_equal_approx(p_rect.size);
 }

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -39,13 +39,7 @@ class String;
 struct Rect2i;
 struct Transform2D;
 
-static int rect2_coverage_testing_data_structure[100];
-
-inline void print_coverage_testing_data_structure(int coverage_array[100]) {
-	for (int i = 0; i < 100; i++) {
-		std::cout << "Path " << i+1 << " was covered " << coverage_array[i] << "times." << std::endl;
-	}
-}
+extern int rect2_coverage_testing_data_structure[100];
 
 struct [[nodiscard]] Rect2 {
 	Point2 position;

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -343,6 +343,91 @@ TEST_CASE("[Rect2] Finite number checks") {
 			"Rect2 with two components infinite should not be finite.");
 }
 
+TEST_CASE("[Rect2] No transform intersects") {
+	CHECK_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0, 0)), Rect2(0, 0, 10, 10)),
+			"Unmoved equivalent Rect2 should intersect."
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0, 0)), Rect2(20, 20, 10, 10)),
+			"Unmoved Rect2 outside of first Rect2 should not intersect."
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0, 0)), Rect2(10, 10, 10, 10)),
+			"Corner Rect2 should not intersect."
+	);
+}
+
+TEST_CASE("[Rect2] Movement transform intersects") {
+	CHECK_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(-20, 0)), Rect2(20, 0, 10, 10)),
+			"Rect2 moved to be equal to other Rect2 should intersect"
+	);
+
+	CHECK_MESSAGE(
+			Rect2(100, 100, 10, 10).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(100, 25)), Rect2(0, 80, 10, 10)),
+			"Rect2 moved to be on other Rect2 should intersect"
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(50, 50, 25, 25).intersects_transformed(Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(0, -100)), Rect2(50, 50, 10, 10)),
+			"Rect2 moved to be out of other Rect2 should not intersect"
+	);
+}
+
+TEST_CASE("[Rect2] Rotated transform intersects") {
+	CHECK_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(cos(0.78), sin(0.78)), Vector2(-sin(0.78), cos(0.78)), Vector2(0, 0)), Rect2(0, 0, 10, 10)),
+			"Equal then rotated Rect2 should intersect"
+	);
+
+	CHECK_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(cos(0.78), sin(0.78)), Vector2(-sin(0.78), cos(0.78)), Vector2(0, 0)), Rect2(11, 0, 10, 10)),
+			"Outside but rotated corner inside should intersect"
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(cos(0.78), sin(0.78)), Vector2(-sin(0.78), cos(0.78)), Vector2(0, 0)), Rect2(9, 9, 10, 10)),
+			"Inside but rotated outside should not intersect"
+	);
+}
+
+/* 
+* Scaling seems to be broken for the intersection, cannot test. 
+*
+TEST_CASE("[Rect2] Scaled transform intersects") {
+	CHECK_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(3, 0), Vector2(0, 3), Vector2(0, 0)), Rect2(0, 0, 10, 10)),
+			"Equal then scaled Rect2 should intersect"
+	);
+
+	CHECK_MESSAGE(
+			Rect2(11, 0, 10, 10).intersects_transformed(Transform2D(Vector2(3, 0), Vector2(0, 3), Vector2(0, 0)), Rect2(0, 0, 10, 10)),
+			"Outside but scaled inside should intersect"
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(12, 0, 10, 10).intersects_transformed(Transform2D(Vector2(0.1, 0), Vector2(0, 0.1), Vector2(0, 0)), Rect2(0, 15, 15, 15)),
+			"Inside then scaled outside Rect2 should not intersect"
+	);
+}
+*/
+
+TEST_CASE("[Rect2] Multiple transform directions") {
+	CHECK_MESSAGE(
+			Rect2(0, 0, 80, 80).intersects_transformed(Transform2D(Vector2(cos(0.78), sin(0.78)), Vector2(-sin(0.78), cos(0.78)), Vector2(5, 5)), Rect2(50, 50, 100, 100)),
+			"Rotated and translated but inside should intersect"
+	);
+
+	CHECK_FALSE_MESSAGE(
+			Rect2(0, 0, 10, 10).intersects_transformed(Transform2D(Vector2(cos(-0.78), sin(-0.78)), Vector2(-sin(-0.78), cos(-0.78)), Vector2(-50, -50)), Rect2(0, 0, 10, 10)),
+			"Rotated and translated outside should not intersect"
+	);
+}
+
+
 } // namespace TestRect2
 
 #endif // TEST_RECT2_H

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -199,6 +199,12 @@
 #endif // _3D_DISABLED
 #include "servers/rendering/rendering_server_default.h"
 
+void print_coverage_testing_data_structure(int coverage_array[100]) {
+	for (int i = 0; i < 100; i++) {
+		std::cout << "Path " << i << " was covered " << coverage_array[i] << " times." << std::endl;
+	}
+}
+
 int test_main(int argc, char *argv[]) {
 	bool run_tests = true;
 

--- a/tests/test_main.h
+++ b/tests/test_main.h
@@ -31,6 +31,8 @@
 #ifndef TEST_MAIN_H
 #define TEST_MAIN_H
 
+void print_coverage_testing_data_structure(int coverage_array[100]);
+
 int test_main(int argc, char *argv[]);
 
 #endif // TEST_MAIN_H


### PR DESCRIPTION
Added general code to handle code coverage, as well as code to do code coverage on specifically Rect2::intersects_transformed. This also adds tests that cover some of the branches in the method. This closes #1, #2 and #3.