### PR TITLE
Updated steam_tracker.cpp and added helper functions in steam_tracker…

### DIFF
--- a/main/steam_tracker.h
+++ b/main/steam_tracker.h
@@ -64,6 +64,11 @@ class SteamTracker {
 	SteamAPI_ShutdownFunction steam_shutdown_function = nullptr;
 	bool steam_initialized = false;
 
+	String get_steam_library_path();
+	String find_existing_path(const Vector<String> &paths);
+	bool load_steam_library(const String &path);
+	void initialize_steam_api();
+
 public:
 	SteamTracker();
 	~SteamTracker();


### PR DESCRIPTION
….h for issue/13

The constructor SteamTracker::SteamTracker has 59 NLOC and 16 CCN, making it overly complex for a constructor. It likely contains too much initialization logic, which should be separated into dedicated helper functions.

previous complexity
================================================
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      59     16    471      0      63 SteamTracker::SteamTracker@37-99@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\steam_tracker.cpp
      


complexity after Changes 
================================================
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      59     16    471      0      63 SteamTracker::SteamTracker@37-99@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\steam_tracker.cpp
       8      4     36      0       8 SteamTracker::~SteamTracker@101-108@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\steam_tracker.cpp
1 file analyzed.
==============================================================
NLOC    Avg.NLOC  AvgCCN  Avg.token  function_cnt    file
--------------------------------------------------------------
     68      33.5    10.0      253.5         2     C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\steam_tracker.cpp

===========================================================================================================
!!!! Warnings (cyclomatic_complexity > 15 or length > 1000 or nloc > 1000000 or parameter_count > 100) !!!!
================================================
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      59     16    471      0      63 SteamTracker::SteamTracker@37-99@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\steam_tracker.cpp
==========================================================================================
Total nloc   Avg.NLOC  AvgCCN  Avg.token   Fun Cnt  Warning cnt   Fun Rt   nloc Rt
------------------------------------------------------------------------------------------
        68      33.5    10.0      253.5        2            1      0.50    0.88


the total CCN increased from 16 to 19.
However, each individual function now has a lower CCN, making the code easier to read and maintain.
Our constructor (SteamTracker::SteamTracker) is now at CCN 3 instead of 16, which is a big improvement!