### PR TITLE
Updated main_timer_sync.cpp and main_timer_sync.h for issue/11

### DIFF
--- a/main/main_timer_sync.h
+++ b/main/main_timer_sync.h
@@ -49,9 +49,15 @@ class MainTimerSync {
 	public:
 		// pass the recorded delta, returns a smoothed delta
 		int64_t smooth_delta(int64_t p_delta);
+		void update_refresh_rate_estimator(int64_t p_delta);
 
 	private:
-		void update_refresh_rate_estimator(int64_t p_delta);
+		// Helper methods to reduce complexity
+		bool accumulate_frame_delta(int64_t &p_delta);
+		bool initialize_fps_estimate(int fps);
+		bool adjust_fps_estimate(int fps);
+		void increase_fps_estimate(int fps);
+		void decrease_fps_estimate(int fps);
 		bool fps_allows_smoothing(int64_t p_delta);
 
 		// estimated vsync delta (monitor refresh rate)


### PR DESCRIPTION
Located in main_timer_sync.cpp the function currently has 83 NLOC and 29 CCN which are very high.
The function needs better structure and modularization.

========
the complexity before changes

================================================
  NLOC    CCN   token  PARAM  length  location
------------------------------------------------
      83     29    459      1     151 MainTimerSync::DeltaSmoother::update_refresh_rate_estimator@46-196@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
==================================================================================

the complexity after changes
================================================
  NLOC    CCN   token  PARAM  length  location
================================================
      20      7     92      1      30 MainTimerSync::DeltaSmoother::update_refresh_rate_estimator@47-76@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
      12      2     53      1      16 MainTimerSync::DeltaSmoother::accumulate_frame_delta@79-94@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
       7      3     33      1       7 MainTimerSync::DeltaSmoother::initialize_fps_estimate@96-102@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
      15      6     66      1      17 MainTimerSync::DeltaSmoother::adjust_fps_estimate@104-120@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
      17      6     91      1      18 MainTimerSync::DeltaSmoother::increase_fps_estimate@122-139@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp
      16      6     76      1      17 MainTimerSync::DeltaSmoother::decrease_fps_estimate@141-157@C:\Users\User117055\OneDrive - Combitech AB\Desktop\godot-DD2480\main\main_timer_sync.cpp

