### PR TITLE
feat: add four new testcases for geometry_3d::get_closest_points_between_segments Issue/#22

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -30,6 +30,8 @@
 
 #include "geometry_3d.h"
 
+int geometry_3d_coverage_testing_data_structure[100];
+
 void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt) {
 	// Based on David Eberly's Computation of Distance Between Line Segments algorithm.
 
@@ -56,7 +58,13 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 			// s <= 0.0f
 			if (e <= 0.0f) {
 				// t <= 0.0f
-				s = (-d >= a ? 1 : (-d > 0.0f ? -d / a : 0.0f));
+                if(-d >= a){
+                    s = 1;
+                } else if (-d > 0.0f){
+                    s = -d/a;
+                } else {
+                    s = 0.0f;
+                }
 				t = 0.0f;
 			} else if (e < c) {
 				// 0.0f < t < 1
@@ -64,7 +72,14 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 				t = e / c;
 			} else {
 				// t >= 1
-				s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
+				//s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
+                if (b - d >= a) {
+                    s = 1;
+                } else if (b - d > 0.0f) {
+                    s = (b - d) / a;
+                } else {
+                    s = 0.0f;
+                }
 				t = 1;
 			}
 		} else {
@@ -74,7 +89,14 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 				// s >= 1
 				if (b + e <= 0.0f) {
 					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
+					//s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
+                    if (-d <= 0.0f) {
+                        s = 0.0f;
+                    } else if (-d < a) {
+                        s = -d / a;
+                    } else {
+                        s = 1;
+                    }
 					t = 0.0f;
 				} else if (b + e < c) {
 					// 0.0f < t < 1
@@ -82,7 +104,14 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 					t = (b + e) / c;
 				} else {
 					// t >= 1
-					s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
+					//s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
+                    if (b - d <= 0.0f) {
+                        s = 0.0f;
+                    } else if (b - d < a) {
+                        s = (b - d) / a;
+                    } else {
+                        s = 1;
+                    }
 					t = 1;
 				}
 			} else {
@@ -92,14 +121,27 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 
 				if (ate <= btd) {
 					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+					//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+                    if (-d <= 0.0f) {
+                        s = 0.0f;
+                    } else if (-d >= a) {
+                        s = 1;
+                    } else {
+                        s = -d / a;
+                    }
 					t = 0.0f;
 				} else {
 					// t > 0.0f
 					t = ate - btd;
 					if (t >= det) {
 						// t >= 1
-						s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+						if(b - d <= 0.0f) {
+                            s = 0.0f;
+                        } else if (b - d >= a) {
+                            s = 1;
+                        } else {
+                            s = (b - d) / a;
+                        }
 						t = 1;
 					} else {
 						// 0.0f < t < 1
@@ -112,7 +154,13 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 	} else {
 		// Parallel segments
 		if (e <= 0.0f) {
-			s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+			if (-d <= 0.0f) {
+                s = 0.0f;
+            } else if (-d >= a) {
+                s = 1;
+            } else {
+                s = -d / a;
+            }
 			t = 0.0f;
 		} else if (e >= c) {
 			s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
@@ -125,6 +173,13 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 
 	r_ps = (1 - s) * p_p0 + s * p_p1;
 	r_qt = (1 - t) * p_q0 + t * p_q1;
+}
+
+real_t Geometry3D::clamp(real_t val, real_t min, real_t max){
+    //could use ternary as in the original, but prefer if else since it is easier to understand whats going on.
+    if(val < min) return min;
+    else if (val > max) return max;
+    else return val;
 }
 
 real_t Geometry3D::get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1) {

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -54,130 +54,130 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		real_t bte = b * e;
 		real_t ctd = c * d;
 
-        geometry_3d_coverage_testing_data_structure[0];
+        geometry_3d_coverage_testing_data_structure[0]++;
 
 		if (bte <= ctd) {
-            geometry_3d_coverage_testing_data_structure[1];
+            geometry_3d_coverage_testing_data_structure[1]++;
 			// s <= 0.0f
 			if (e <= 0.0f) {
-                geometry_3d_coverage_testing_data_structure[2];
+                geometry_3d_coverage_testing_data_structure[2]++;
 				// t <= 0.0f
                 if(-d >= a){
-                    geometry_3d_coverage_testing_data_structure[3];
+                    geometry_3d_coverage_testing_data_structure[3]++;
                     s = 1;
                 } else if (-d > 0.0f){
-                    geometry_3d_coverage_testing_data_structure[4];
+                    geometry_3d_coverage_testing_data_structure[4]++;
                     s = -d/a;
                 } else {
-                    geometry_3d_coverage_testing_data_structure[5];
+                    geometry_3d_coverage_testing_data_structure[5]++;
                     s = 0.0f;
                 }
 				t = 0.0f;
 			} else if (e < c) {
-                geometry_3d_coverage_testing_data_structure[6];
+                geometry_3d_coverage_testing_data_structure[6]++;
 				// 0.0f < t < 1
 				s = 0.0f;
 				t = e / c;
 			} else {
-                geometry_3d_coverage_testing_data_structure[7];
+                geometry_3d_coverage_testing_data_structure[7]++;
 				// t >= 1
 				//s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
                 if (b - d >= a) {
-                    geometry_3d_coverage_testing_data_structure[8];
+                    geometry_3d_coverage_testing_data_structure[8]++;
                     s = 1;
                 } else if (b - d > 0.0f) {
-                    geometry_3d_coverage_testing_data_structure[9];
+                    geometry_3d_coverage_testing_data_structure[9]++;
                     s = (b - d) / a;
                 } else {
-                    geometry_3d_coverage_testing_data_structure[10];
+                    geometry_3d_coverage_testing_data_structure[10]++;
                     s = 0.0f;
                 }
 				t = 1;
 			}
 		} else {
-            geometry_3d_coverage_testing_data_structure[11];
+            geometry_3d_coverage_testing_data_structure[11]++;
 			// s > 0.0f
 			s = bte - ctd;
 			if (s >= det) {
-                geometry_3d_coverage_testing_data_structure[12];
+                geometry_3d_coverage_testing_data_structure[12]++;
 				// s >= 1
 				if (b + e <= 0.0f) {
-                    geometry_3d_coverage_testing_data_structure[13];
+                    geometry_3d_coverage_testing_data_structure[13]++;
 					// t <= 0.0f
 					//s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
                     if (-d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[14];
+                        geometry_3d_coverage_testing_data_structure[14]++;
                         s = 0.0f;
                     } else if (-d < a) {
-                        geometry_3d_coverage_testing_data_structure[15];
+                        geometry_3d_coverage_testing_data_structure[15]++;
                         s = -d / a;
                     } else {
-                        geometry_3d_coverage_testing_data_structure[16];
+                        geometry_3d_coverage_testing_data_structure[16]++;
                         s = 1;
                     }
 					t = 0.0f;
 				} else if (b + e < c) {
-                    geometry_3d_coverage_testing_data_structure[17];
+                    geometry_3d_coverage_testing_data_structure[17]++;
 					// 0.0f < t < 1
 					s = 1;
 					t = (b + e) / c;
 				} else {
-                    geometry_3d_coverage_testing_data_structure[18];
+                    geometry_3d_coverage_testing_data_structure[18]++;
 					// t >= 1
 					//s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
                     if (b - d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[19];
+                        geometry_3d_coverage_testing_data_structure[19]++;
                         s = 0.0f;
                     } else if (b - d < a) {
-                        geometry_3d_coverage_testing_data_structure[20];
+                        geometry_3d_coverage_testing_data_structure[20]++;
                         s = (b - d) / a;
                     } else {
-                        geometry_3d_coverage_testing_data_structure[21];
+                        geometry_3d_coverage_testing_data_structure[21]++;
                         s = 1;
                     }
 					t = 1;
 				}
 			} else {
-                geometry_3d_coverage_testing_data_structure[22];
+                geometry_3d_coverage_testing_data_structure[22]++;
 				// 0.0f < s < 1
 				real_t ate = a * e;
 				real_t btd = b * d;
 
 				if (ate <= btd) {
-                    geometry_3d_coverage_testing_data_structure[23];
+                    geometry_3d_coverage_testing_data_structure[23]++;
 					// t <= 0.0f
 					//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
                     if (-d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[24];
+                        geometry_3d_coverage_testing_data_structure[24]++;
                         s = 0.0f;
                     } else if (-d >= a) {
-                        geometry_3d_coverage_testing_data_structure[25];
+                        geometry_3d_coverage_testing_data_structure[25]++;
                         s = 1;
                     } else {
-                        geometry_3d_coverage_testing_data_structure[26];
+                        geometry_3d_coverage_testing_data_structure[26]++;
                         s = -d / a;
                     }
 					t = 0.0f;
 				} else {
-                    geometry_3d_coverage_testing_data_structure[27];
+                    geometry_3d_coverage_testing_data_structure[27]++;
 					// t > 0.0f
 					t = ate - btd;
 					if (t >= det) {
-                        geometry_3d_coverage_testing_data_structure[28];
+                        geometry_3d_coverage_testing_data_structure[28]++;
 						// t >= 1
 						if(b - d <= 0.0f) {
-                            geometry_3d_coverage_testing_data_structure[29];
+                            geometry_3d_coverage_testing_data_structure[29]++;
                             s = 0.0f;
                         } else if (b - d >= a) {
-                            geometry_3d_coverage_testing_data_structure[30];
+                            geometry_3d_coverage_testing_data_structure[30]++;
                             s = 1;
                         } else {
-                            geometry_3d_coverage_testing_data_structure[31];
+                            geometry_3d_coverage_testing_data_structure[31]++;
                             s = (b - d) / a;
                         }
 						t = 1;
 					} else {
-                        geometry_3d_coverage_testing_data_structure[32];
+                        geometry_3d_coverage_testing_data_structure[32]++;
 						// 0.0f < t < 1
 						s /= det;
 						t /= det;
@@ -187,35 +187,35 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		}
 	} else {
 		// Parallel segments
-        geometry_3d_coverage_testing_data_structure[33];
+        geometry_3d_coverage_testing_data_structure[33]++;
 		if (e <= 0.0f) {
-            geometry_3d_coverage_testing_data_structure[34];
+            geometry_3d_coverage_testing_data_structure[34]++;
 			if (-d <= 0.0f) {
-                geometry_3d_coverage_testing_data_structure[35];
+                geometry_3d_coverage_testing_data_structure[35]++;
                 s = 0.0f;
             } else if (-d >= a) {
-                geometry_3d_coverage_testing_data_structure[36];
+                geometry_3d_coverage_testing_data_structure[36]++;
                 s = 1;
             } else {
-                geometry_3d_coverage_testing_data_structure[37];
+                geometry_3d_coverage_testing_data_structure[37]++;
                 s = -d / a;
             }
 			t = 0.0f;
 		} else if (e >= c) {
-            geometry_3d_coverage_testing_data_structure[38];
+            geometry_3d_coverage_testing_data_structure[38]++;
 			if (b - d <= 0.0f) {
-                geometry_3d_coverage_testing_data_structure[39];
+                geometry_3d_coverage_testing_data_structure[39]++;
                 s = 0.0f;
             } else if (b - d >= a) {
-                geometry_3d_coverage_testing_data_structure[40];
+                geometry_3d_coverage_testing_data_structure[40]++;
                 s = 1;
             } else {
-                geometry_3d_coverage_testing_data_structure[41];
+                geometry_3d_coverage_testing_data_structure[41]++;
                 s = (b - d) / a;
             }
 			t = 1;
 		} else {
-            geometry_3d_coverage_testing_data_structure[42];
+            geometry_3d_coverage_testing_data_structure[42]++;
 			s = 0.0f;
 			t = e / c;
 		}

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -54,96 +54,130 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		real_t bte = b * e;
 		real_t ctd = c * d;
 
+        geometry_3d_coverage_testing_data_structure[0];
+
 		if (bte <= ctd) {
+            geometry_3d_coverage_testing_data_structure[1];
 			// s <= 0.0f
 			if (e <= 0.0f) {
+                geometry_3d_coverage_testing_data_structure[2];
 				// t <= 0.0f
                 if(-d >= a){
+                    geometry_3d_coverage_testing_data_structure[3];
                     s = 1;
                 } else if (-d > 0.0f){
+                    geometry_3d_coverage_testing_data_structure[4];
                     s = -d/a;
                 } else {
+                    geometry_3d_coverage_testing_data_structure[5];
                     s = 0.0f;
                 }
 				t = 0.0f;
 			} else if (e < c) {
+                geometry_3d_coverage_testing_data_structure[6];
 				// 0.0f < t < 1
 				s = 0.0f;
 				t = e / c;
 			} else {
+                geometry_3d_coverage_testing_data_structure[7];
 				// t >= 1
 				//s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
                 if (b - d >= a) {
+                    geometry_3d_coverage_testing_data_structure[8];
                     s = 1;
                 } else if (b - d > 0.0f) {
+                    geometry_3d_coverage_testing_data_structure[9];
                     s = (b - d) / a;
                 } else {
+                    geometry_3d_coverage_testing_data_structure[10];
                     s = 0.0f;
                 }
 				t = 1;
 			}
 		} else {
+            geometry_3d_coverage_testing_data_structure[11];
 			// s > 0.0f
 			s = bte - ctd;
 			if (s >= det) {
+                geometry_3d_coverage_testing_data_structure[12];
 				// s >= 1
 				if (b + e <= 0.0f) {
+                    geometry_3d_coverage_testing_data_structure[13];
 					// t <= 0.0f
 					//s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
                     if (-d <= 0.0f) {
+                        geometry_3d_coverage_testing_data_structure[14];
                         s = 0.0f;
                     } else if (-d < a) {
+                        geometry_3d_coverage_testing_data_structure[15];
                         s = -d / a;
                     } else {
+                        geometry_3d_coverage_testing_data_structure[16];
                         s = 1;
                     }
 					t = 0.0f;
 				} else if (b + e < c) {
+                    geometry_3d_coverage_testing_data_structure[17];
 					// 0.0f < t < 1
 					s = 1;
 					t = (b + e) / c;
 				} else {
+                    geometry_3d_coverage_testing_data_structure[18];
 					// t >= 1
 					//s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
                     if (b - d <= 0.0f) {
+                        geometry_3d_coverage_testing_data_structure[19];
                         s = 0.0f;
                     } else if (b - d < a) {
+                        geometry_3d_coverage_testing_data_structure[20];
                         s = (b - d) / a;
                     } else {
+                        geometry_3d_coverage_testing_data_structure[21];
                         s = 1;
                     }
 					t = 1;
 				}
 			} else {
+                geometry_3d_coverage_testing_data_structure[22];
 				// 0.0f < s < 1
 				real_t ate = a * e;
 				real_t btd = b * d;
 
 				if (ate <= btd) {
+                    geometry_3d_coverage_testing_data_structure[23];
 					// t <= 0.0f
 					//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
                     if (-d <= 0.0f) {
+                        geometry_3d_coverage_testing_data_structure[24];
                         s = 0.0f;
                     } else if (-d >= a) {
+                        geometry_3d_coverage_testing_data_structure[25];
                         s = 1;
                     } else {
+                        geometry_3d_coverage_testing_data_structure[26];
                         s = -d / a;
                     }
 					t = 0.0f;
 				} else {
+                    geometry_3d_coverage_testing_data_structure[27];
 					// t > 0.0f
 					t = ate - btd;
 					if (t >= det) {
+                        geometry_3d_coverage_testing_data_structure[28];
 						// t >= 1
 						if(b - d <= 0.0f) {
+                            geometry_3d_coverage_testing_data_structure[29];
                             s = 0.0f;
                         } else if (b - d >= a) {
+                            geometry_3d_coverage_testing_data_structure[30];
                             s = 1;
                         } else {
+                            geometry_3d_coverage_testing_data_structure[31];
                             s = (b - d) / a;
                         }
 						t = 1;
 					} else {
+                        geometry_3d_coverage_testing_data_structure[32];
 						// 0.0f < t < 1
 						s /= det;
 						t /= det;
@@ -153,19 +187,35 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		}
 	} else {
 		// Parallel segments
+        geometry_3d_coverage_testing_data_structure[33];
 		if (e <= 0.0f) {
+            geometry_3d_coverage_testing_data_structure[34];
 			if (-d <= 0.0f) {
+                geometry_3d_coverage_testing_data_structure[35];
                 s = 0.0f;
             } else if (-d >= a) {
+                geometry_3d_coverage_testing_data_structure[36];
                 s = 1;
             } else {
+                geometry_3d_coverage_testing_data_structure[37];
                 s = -d / a;
             }
 			t = 0.0f;
 		} else if (e >= c) {
-			s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+            geometry_3d_coverage_testing_data_structure[38];
+			if (b - d <= 0.0f) {
+                geometry_3d_coverage_testing_data_structure[39];
+                s = 0.0f;
+            } else if (b - d >= a) {
+                geometry_3d_coverage_testing_data_structure[40];
+                s = 1;
+            } else {
+                geometry_3d_coverage_testing_data_structure[41];
+                s = (b - d) / a;
+            }
 			t = 1;
 		} else {
+            geometry_3d_coverage_testing_data_structure[42];
 			s = 0.0f;
 			t = e / c;
 		}

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -62,123 +62,64 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 			if (e <= 0.0f) {
                 geometry_3d_coverage_testing_data_structure[2]++;
 				// t <= 0.0f
-                if(-d >= a){
-                    geometry_3d_coverage_testing_data_structure[3]++;
-                    s = 1;
-                } else if (-d > 0.0f){
-                    geometry_3d_coverage_testing_data_structure[4]++;
-                    s = -d/a;
-                } else {
-                    geometry_3d_coverage_testing_data_structure[5]++;
-                    s = 0.0f;
-                }
+				s = (-d >= a ? 1 : (-d > 0.0f ? -d / a : 0.0f));
 				t = 0.0f;
 			} else if (e < c) {
-                geometry_3d_coverage_testing_data_structure[6]++;
+                geometry_3d_coverage_testing_data_structure[3]++;
 				// 0.0f < t < 1
 				s = 0.0f;
 				t = e / c;
 			} else {
-                geometry_3d_coverage_testing_data_structure[7]++;
 				// t >= 1
-				//s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
-                if (b - d >= a) {
-                    geometry_3d_coverage_testing_data_structure[8]++;
-                    s = 1;
-                } else if (b - d > 0.0f) {
-                    geometry_3d_coverage_testing_data_structure[9]++;
-                    s = (b - d) / a;
-                } else {
-                    geometry_3d_coverage_testing_data_structure[10]++;
-                    s = 0.0f;
-                }
+                geometry_3d_coverage_testing_data_structure[4]++;
+				s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
 				t = 1;
 			}
 		} else {
-            geometry_3d_coverage_testing_data_structure[11]++;
 			// s > 0.0f
+            geometry_3d_coverage_testing_data_structure[5]++;
 			s = bte - ctd;
 			if (s >= det) {
-                geometry_3d_coverage_testing_data_structure[12]++;
 				// s >= 1
 				if (b + e <= 0.0f) {
-                    geometry_3d_coverage_testing_data_structure[13]++;
 					// t <= 0.0f
-					//s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
-                    if (-d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[14]++;
-                        s = 0.0f;
-                    } else if (-d < a) {
-                        geometry_3d_coverage_testing_data_structure[15]++;
-                        s = -d / a;
-                    } else {
-                        geometry_3d_coverage_testing_data_structure[16]++;
-                        s = 1;
-                    }
+                    geometry_3d_coverage_testing_data_structure[6]++;
+					s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
 					t = 0.0f;
 				} else if (b + e < c) {
-                    geometry_3d_coverage_testing_data_structure[17]++;
+                    geometry_3d_coverage_testing_data_structure[7]++;
 					// 0.0f < t < 1
 					s = 1;
 					t = (b + e) / c;
 				} else {
-                    geometry_3d_coverage_testing_data_structure[18]++;
+                    geometry_3d_coverage_testing_data_structure[8]++;
 					// t >= 1
-					//s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
-                    if (b - d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[19]++;
-                        s = 0.0f;
-                    } else if (b - d < a) {
-                        geometry_3d_coverage_testing_data_structure[20]++;
-                        s = (b - d) / a;
-                    } else {
-                        geometry_3d_coverage_testing_data_structure[21]++;
-                        s = 1;
-                    }
+					s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
 					t = 1;
 				}
 			} else {
-                geometry_3d_coverage_testing_data_structure[22]++;
 				// 0.0f < s < 1
 				real_t ate = a * e;
 				real_t btd = b * d;
+                geometry_3d_coverage_testing_data_structure[9]++;
 
 				if (ate <= btd) {
-                    geometry_3d_coverage_testing_data_structure[23]++;
 					// t <= 0.0f
-					//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
-                    if (-d <= 0.0f) {
-                        geometry_3d_coverage_testing_data_structure[24]++;
-                        s = 0.0f;
-                    } else if (-d >= a) {
-                        geometry_3d_coverage_testing_data_structure[25]++;
-                        s = 1;
-                    } else {
-                        geometry_3d_coverage_testing_data_structure[26]++;
-                        s = -d / a;
-                    }
+                    geometry_3d_coverage_testing_data_structure[10]++;
+					s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
 					t = 0.0f;
 				} else {
-                    geometry_3d_coverage_testing_data_structure[27]++;
 					// t > 0.0f
+                    geometry_3d_coverage_testing_data_structure[11]++;
 					t = ate - btd;
 					if (t >= det) {
-                        geometry_3d_coverage_testing_data_structure[28]++;
 						// t >= 1
-						if(b - d <= 0.0f) {
-                            geometry_3d_coverage_testing_data_structure[29]++;
-                            s = 0.0f;
-                        } else if (b - d >= a) {
-                            geometry_3d_coverage_testing_data_structure[30]++;
-                            s = 1;
-                        } else {
-                            geometry_3d_coverage_testing_data_structure[31]++;
-                            s = (b - d) / a;
-                        }
+                        geometry_3d_coverage_testing_data_structure[12]++;
+						s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
 						t = 1;
 					} else {
-                        geometry_3d_coverage_testing_data_structure[32]++;
 						// 0.0f < t < 1
+                        geometry_3d_coverage_testing_data_structure[13]++;
 						s /= det;
 						t /= det;
 					}
@@ -187,35 +128,16 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 		}
 	} else {
 		// Parallel segments
-        geometry_3d_coverage_testing_data_structure[33]++;
 		if (e <= 0.0f) {
-            geometry_3d_coverage_testing_data_structure[34]++;
-			if (-d <= 0.0f) {
-                geometry_3d_coverage_testing_data_structure[35]++;
-                s = 0.0f;
-            } else if (-d >= a) {
-                geometry_3d_coverage_testing_data_structure[36]++;
-                s = 1;
-            } else {
-                geometry_3d_coverage_testing_data_structure[37]++;
-                s = -d / a;
-            }
+            geometry_3d_coverage_testing_data_structure[14]++;
+			s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
 			t = 0.0f;
 		} else if (e >= c) {
-            geometry_3d_coverage_testing_data_structure[38]++;
-			if (b - d <= 0.0f) {
-                geometry_3d_coverage_testing_data_structure[39]++;
-                s = 0.0f;
-            } else if (b - d >= a) {
-                geometry_3d_coverage_testing_data_structure[40]++;
-                s = 1;
-            } else {
-                geometry_3d_coverage_testing_data_structure[41]++;
-                s = (b - d) / a;
-            }
+            geometry_3d_coverage_testing_data_structure[15]++;
+			s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
 			t = 1;
 		} else {
-            geometry_3d_coverage_testing_data_structure[42]++;
+            geometry_3d_coverage_testing_data_structure[16]++;
 			s = 0.0f;
 			t = e / c;
 		}
@@ -223,13 +145,6 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 
 	r_ps = (1 - s) * p_p0 + s * p_p1;
 	r_qt = (1 - t) * p_q0 + t * p_q1;
-}
-
-real_t Geometry3D::clamp(real_t val, real_t min, real_t max){
-    //could use ternary as in the original, but prefer if else since it is easier to understand whats going on.
-    if(val < min) return min;
-    else if (val > max) return max;
-    else return val;
 }
 
 real_t Geometry3D::get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -37,7 +37,12 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/vector.h"
 
+extern int geometry_3d_coverage_testing_data_structure[100];
+
 class Geometry3D {
+private:
+    real_t clamp(real_t value, real_t min, real_t max);
+
 public:
 	static void get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt);
 	static real_t get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1);

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -40,8 +40,6 @@
 extern int geometry_3d_coverage_testing_data_structure[100];
 
 class Geometry3D {
-private:
-    real_t clamp(real_t value, real_t min, real_t max);
 
 public:
 	static void get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt);

--- a/tests/core/math/test_geometry_3d.h
+++ b/tests/core/math/test_geometry_3d.h
@@ -42,6 +42,42 @@ TEST_CASE("[Geometry3D] Closest Points Between Segments") {
 	CHECK(qt.is_equal_approx(Vector3(-1, -0.2, 0.2)));
 }
 
+/////////segments added by rifat//////
+TEST_CASE("[Geometry3D] Closest Points Between Segments") {
+	Vector3 ps, qt;
+	Geometry3D::get_closest_points_between_segments(Vector3(0, 0, 0), Vector3(0, 0, 1), Vector3(1, 0, 0), Vector3(1, 0, 1), ps, qt);
+    real_t x = ps.AXIS_X;
+    real_t y = ps.AXIS_X;
+    real_t z = ps.AXIS_X;
+    CHECK(x == 0);
+    CHECK(y == 0);
+    CHECK(z <= 1);
+    CHECK(0 <= z);
+	CHECK(qt.is_equal_approx(Vector3(1, 0, z)));
+}
+
+TEST_CASE("[Geometry3D] Closest Points Between Segments") {
+	Vector3 ps, qt;
+	Geometry3D::get_closest_points_between_segments(Vector3(0, 0, 0), Vector3(0, 0, 1), Vector3(-5, 0, 5), Vector3(5, 0, 5), ps, qt);
+	CHECK(ps.is_equal_approx(Vector3(0, 0, 1)));
+	CHECK(qt.is_equal_approx(Vector3(0, 0, 5)));
+}
+
+TEST_CASE("[Geometry3D] Closest Points Between Segments") {
+	Vector3 ps, qt;
+	Geometry3D::get_closest_points_between_segments(Vector3(0, 0, 0), Vector3(0, 0, 1), Vector3(-0.5, 0, 0), Vector3(0.5, 0, 0), ps, qt);
+	CHECK(ps.is_equal_approx(Vector3(0, 0, 0)));
+	CHECK(qt.is_equal_approx(Vector3(0, 0, 0)));
+}
+
+TEST_CASE("[Geometry3D] Closest Points Between Segments") {
+	Vector3 ps, qt;
+	Geometry3D::get_closest_points_between_segments(Vector3(0, 0, 0), Vector3(1, 0, 0), Vector3(0, 1, 0), Vector3(0, 2, 0), ps, qt);
+	CHECK(ps.is_equal_approx(Vector3(0, 0, 0)));
+	CHECK(qt.is_equal_approx(Vector3(0, 1, 0)));
+}
+///////////////////////////////////////
+
 TEST_CASE("[Geometry3D] Closest Distance Between Segments") {
 	CHECK(Geometry3D::get_closest_distance_between_segments(Vector3(1, -2, 0), Vector3(1, 2, 0), Vector3(-1, 2, 0), Vector3(-1, -2, 0)) == 2.0f);
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -272,6 +272,7 @@ int test_main(int argc, char *argv[]) {
 
 	print_coverage_testing_data_structure(rect2_coverage_testing_data_structure);
 	print_coverage_testing_data_structure(basis_coverage_testing_data_structure);
+    print_coverage_testing_data_structure(geometry_3d_coverage_testing_data_structure);
 
 	return res;
 }


### PR DESCRIPTION
Add four new test cases for geometry_3d.h to improve test coverage.
Goes from 5/17 to 11/17. (Does not check coverage on ternary expressions)

This closes #22 