### PR TITLE
refactor: introduce clamp function to calculate the value of s instead of using ternary operators. issue/#21

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -56,7 +56,8 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 			// s <= 0.0f
 			if (e <= 0.0f) {
 				// t <= 0.0f
-				s = (-d >= a ? 1 : (-d > 0.0f ? -d / a : 0.0f));
+				//s = (-d >= a ? 1 : (-d > 0.0f ? -d / a : 0.0f));
+                s = clamp(-d, 0.0f, a);
 				t = 0.0f;
 			} else if (e < c) {
 				// 0.0f < t < 1
@@ -64,7 +65,8 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 				t = e / c;
 			} else {
 				// t >= 1
-				s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
+				//s = (b - d >= a ? 1 : (b - d > 0.0f ? (b - d) / a : 0.0f));
+                s = clamp(b-d, 0.0f, a);
 				t = 1;
 			}
 		} else {
@@ -74,7 +76,8 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 				// s >= 1
 				if (b + e <= 0.0f) {
 					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
+					//s = (-d <= 0.0f ? 0.0f : (-d < a ? -d / a : 1));
+                    s = clamp(-d, 0.0f, a);
 					t = 0.0f;
 				} else if (b + e < c) {
 					// 0.0f < t < 1
@@ -82,7 +85,8 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 					t = (b + e) / c;
 				} else {
 					// t >= 1
-					s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
+					//s = (b - d <= 0.0f ? 0.0f : (b - d < a ? (b - d) / a : 1));
+                    s = clamp(b-d, 0.0f, a);
 					t = 1;
 				}
 			} else {
@@ -92,14 +96,16 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 
 				if (ate <= btd) {
 					// t <= 0.0f
-					s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+					//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+                    s = clamp(-d, 0.0f, a);
 					t = 0.0f;
 				} else {
 					// t > 0.0f
 					t = ate - btd;
 					if (t >= det) {
 						// t >= 1
-						s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+						//s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+                        s = clamp(b - d, 0.0f, a);
 						t = 1;
 					} else {
 						// 0.0f < t < 1
@@ -112,10 +118,12 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 	} else {
 		// Parallel segments
 		if (e <= 0.0f) {
-			s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+			//s = (-d <= 0.0f ? 0.0f : (-d >= a ? 1 : -d / a));
+            s = clamp(-d, 0.0f, a);
 			t = 0.0f;
 		} else if (e >= c) {
-			s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+			//s = (b - d <= 0.0f ? 0.0f : (b - d >= a ? 1 : (b - d) / a));
+            s = clamp(b - d, 0.0f, a);
 			t = 1;
 		} else {
 			s = 0.0f;
@@ -125,6 +133,12 @@ void Geometry3D::get_closest_points_between_segments(const Vector3 &p_p0, const 
 
 	r_ps = (1 - s) * p_p0 + s * p_p1;
 	r_qt = (1 - t) * p_q0 + t * p_q1;
+}
+
+real_t Geometry3D::clamp(real_t val, real_t min, real_t max){
+    if(val <= min) return min;
+    else if(val >= max) return 1;
+    else return val / max;
 }
 
 real_t Geometry3D::get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1) {

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -38,6 +38,9 @@
 #include "core/templates/vector.h"
 
 class Geometry3D {
+private:
+    static real_t clamp(real_t val, real_t min, real_t max);
+
 public:
 	static void get_closest_points_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1, Vector3 &r_ps, Vector3 &r_qt);
 	static real_t get_closest_distance_between_segments(const Vector3 &p_p0, const Vector3 &p_p1, const Vector3 &p_q0, const Vector3 &p_q1);


### PR DESCRIPTION
This lowers the ccn of Geometry3D::get_closest_points_between_segments by removing ternary operators that were all doing the same thing. If the value they were comparing with was under 0 s is suppsed to be 0, if the value is greater than a then its supposed to be a and otherwise its the value / a.

This lowers the ccn of Geometry3D::get_closest_points_between_segments from 29 to 16, also introduces a new function clamp with ccn of 3. Together they have a new ccn of 16+3+(1?) = 20.

This closes #21 